### PR TITLE
DNM rtt: update to support const device objects

### DIFF
--- a/rtt/SEGGER_RTT_zephyr.c
+++ b/rtt/SEGGER_RTT_zephyr.c
@@ -21,7 +21,7 @@
 
 K_MUTEX_DEFINE(rtt_term_mutex);
 
-static int rtt_init(struct device *unused)
+static int rtt_init(const struct device *unused)
 {
 	ARG_UNUSED(unused);
 


### PR DESCRIPTION
Init function entry points will now take a pointer to a const struct
device.  Avoid an incompatible pointer assignment.

DNM until plan for changing to const devices is in place.

Ref zephyrproject-rtos/zephyr#25208
