### PR TITLE
rtt: Device instance are all constant now

### DIFF
--- a/rtt/SEGGER_RTT_zephyr.c
+++ b/rtt/SEGGER_RTT_zephyr.c
@@ -21,7 +21,7 @@
 
 K_MUTEX_DEFINE(rtt_term_mutex);
 
-static int rtt_init(struct device *unused)
+static int rtt_init(const struct device *unused)
 {
 	ARG_UNUSED(unused);
 


### PR DESCRIPTION
Switching device parameter to constant.

Signed-off-by: Tomasz Bursztyka <tomasz.bursztyka@linux.intel.com>