### PR TITLE
debug: SystemView post-mortem feature

### DIFF
--- a/systemview/SEGGER_SYSVIEW_Conf.h
+++ b/systemview/SEGGER_SYSVIEW_Conf.h
@@ -10,6 +10,7 @@ uint32_t sysview_get_timestamp(void);
 uint32_t sysview_get_interrupt(void);
 
 #define SEGGER_SYSVIEW_RTT_BUFFER_SIZE CONFIG_SEGGER_SYSVIEW_RTT_BUFFER_SIZE
+#define SEGGER_SYSVIEW_POST_MORTEM_MODE CONFIG_SEGGER_SYSVIEW_POST_MORTEM_MODE
 
 // Lock SystemView (nestable)
 #define SEGGER_SYSVIEW_LOCK()	{					       \


### PR DESCRIPTION
This change adds a KConfig option for post-mortem debugging. Additional PR for the Kconfig option can be found here: https://github.com/zephyrproject-rtos/zephyr/pull/27546.

Signed-off-by: Mattia Fiumara <mattia.fiumara@bgrid.com>