### PR TITLE
rtt: systemview: Add linker section options

### DIFF
--- a/rtt/SEGGER_RTT_Conf.h
+++ b/rtt/SEGGER_RTT_Conf.h
@@ -91,6 +91,10 @@ Revision: $Rev: 13430 $
 
 #define USE_RTT_ASM                               (0) // Use assembler version of SEGGER_RTT.c when 1
 
+#if defined(CONFIG_SEGGER_RTT_SECTION_DTCM)
+#define SEGGER_RTT_SECTION                        ".dtcm_data"
+#endif
+
 /*********************************************************************
 *
 *       RTT memcpy configuration

--- a/systemview/SEGGER_SYSVIEW_Conf.h
+++ b/systemview/SEGGER_SYSVIEW_Conf.h
@@ -12,6 +12,10 @@ uint32_t sysview_get_interrupt(void);
 #define SEGGER_SYSVIEW_RTT_BUFFER_SIZE CONFIG_SEGGER_SYSVIEW_RTT_BUFFER_SIZE
 #define SEGGER_SYSVIEW_POST_MORTEM_MODE CONFIG_SEGGER_SYSVIEW_POST_MORTEM_MODE
 
+#if defined(CONFIG_SEGGER_SYSVIEW_SECTION_DTCM)
+#define SEGGER_SYSVIEW_SECTION	".dtcm_data"
+#endif
+
 // Lock SystemView (nestable)
 #define SEGGER_SYSVIEW_LOCK()	{					       \
 					unsigned int __sysview_irq_key =       \


### PR DESCRIPTION
Enables optionally placing Segger RTT and SystemView data in the DTCM
linker section instead of the default data section. This is needed on
SoCs in the i.MX RT series that use cacheable external SDRAM to store
data.

Signed-off-by: Maureen Helm <maureen.helm@nxp.com>