### PR TITLE
zephyr: use customer locking based on Kconfig

### DIFF
--- a/Config/SEGGER_RTT_Conf.h
+++ b/Config/SEGGER_RTT_Conf.h
@@ -156,7 +156,7 @@ Revision: $Rev: 21386 $
 *       Rowley CrossStudio and GCC
 */
 #if ((defined(__SES_ARM) || defined(__SES_RISCV) || defined(__CROSSWORKS_ARM) || defined(__GNUC__) || defined(__clang__)) && !defined (__CC_ARM) && !defined(WIN32))
-  #ifdef __ZEPHYR__
+  #if defined(__ZEPHYR__) && defined (CONFIG_SEGGER_RTT_CUSTOM_LOCKING)
     #include <kernel.h>
     extern struct k_mutex rtt_term_mutex;
     #define SEGGER_RTT_LOCK() k_mutex_lock(&rtt_term_mutex, K_FOREVER);


### PR DESCRIPTION
Make overriding default locking configurable. The mutex being used here
is interferring with trace tools and generating assertions in some trace
hooks.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>