### PR TITLE
config: Fix lock macro syntax for no multithreading case

### DIFF
--- a/Config/SEGGER_RTT_Conf.h
+++ b/Config/SEGGER_RTT_Conf.h
@@ -154,7 +154,7 @@ Revision: $Rev: 21386 $
       #define SEGGER_RTT_UNLOCK() k_mutex_unlock(&rtt_term_mutex);
     #else
       #define SEGGER_RTT_LOCK() { \
-        unsigned int key = irq_lock()
+        unsigned int key = irq_lock();
       #define SEGGER_RTT_UNLOCK() irq_unlock(key); \
         }
     #endif


### PR DESCRIPTION
Add semicolon. This does compile without it, but will generate an
error if an additional line is added to the macro.

Signed-off-by: Bryce Wilkins <bryce@whisper.ai>