### PR TITLE
Resolve circular include dependencies

### DIFF
--- a/Config/SEGGER_RTT_Conf.h
+++ b/Config/SEGGER_RTT_Conf.h
@@ -147,15 +147,17 @@ Revision: $Rev: 21386 $
 */
 #if ((defined(__SES_ARM) || defined(__SES_RISCV) || defined(__CROSSWORKS_ARM) || defined(__GNUC__) || defined(__clang__)) && !defined (__CC_ARM) && !defined(WIN32))
   #if defined(__ZEPHYR__) && defined (CONFIG_SEGGER_RTT_CUSTOM_LOCKING)
-    #include <zephyr/kernel.h>
     #ifdef CONFIG_MULTITHREADING
-      extern struct k_mutex rtt_term_mutex;
-      #define SEGGER_RTT_LOCK() k_mutex_lock(&rtt_term_mutex, K_FOREVER);
-      #define SEGGER_RTT_UNLOCK() k_mutex_unlock(&rtt_term_mutex);
+      extern void zephyr_rtt_mutex_lock(void);
+      extern void zephyr_rtt_mutex_unlock(void);
+      #define SEGGER_RTT_LOCK() zephyr_rtt_mutex_lock()
+      #define SEGGER_RTT_UNLOCK() zephyr_rtt_mutex_unlock()
     #else
+      extern unsigned int zephyr_rtt_irq_lock(void);
+      extern void zephyr_rtt_irq_unlock(unsigned int key);
       #define SEGGER_RTT_LOCK() { \
-        unsigned int key = irq_lock()
-      #define SEGGER_RTT_UNLOCK() irq_unlock(key); \
+        unsigned int key = zephyr_rtt_irq_lock()
+      #define SEGGER_RTT_UNLOCK() zephyr_rtt_irq_unlock(key); \
         }
     #endif
     #define RTT_USE_ASM 0


### PR DESCRIPTION
CONFIG_SEGGER_SYSTEMVIEW=y does not compile for Cortex-M targets anymore. This is caused by circular include dependencies.

Zephyr kernel is dependend on trace.
Trace is dependend on segger rtt.
Segger rtt MUST NOT be dependend on zephyr kernel.

Therefore remove the `#include <zephyr/kernel.h>` in SEGGER_RTT_Conf.h and replace them with a wrapper function which has to be implemented in the zephyr part.

Note: This will introduce a performance penalty since the compiler won't be able to inline as much anymore, but I don't see any other (clean) way to solve this.

This fixes zephyrproject-rtos/zephyr#43887.