### PR TITLE
Segger RTT: support CONFIG_SEGGER_RTT_INIT_MODE and optimizations

### DIFF
--- a/Config/SEGGER_RTT_Conf.h
+++ b/Config/SEGGER_RTT_Conf.h
@@ -98,7 +98,7 @@ Revision: $Rev: 24316 $
 #define SEGGER_RTT_SECTION                        ".dtcm_data"
 #elif defined(CONFIG_SEGGER_RTT_SECTION_CCM)
 #define SEGGER_RTT_SECTION                        ".ccm_data"
-#elif defined(CONFIG_SEGGER_RTT_SECTION_CUSTOM)
+#elif defined(CONFIG_SEGGER_RTT_SECTION_CUSTOM) || defined(CONFIG_SEGGER_RTT_SECTION_CUSTOM_DTS_REGION)
 #define SEGGER_RTT_SECTION                        CONFIG_SEGGER_RTT_SECTION_CUSTOM_NAME
 #endif
 


### PR DESCRIPTION
 * Different initialization modes of Control Block
 * Safer INIT() like in SystemView V352a
 * Made _aTerminalId const like in SystemView V352a

Fixes #53544.