### PR TITLE
zephyr: use external Kconfig

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,3 +1,4 @@
 name: segger
 build:
   cmake-ext: True
+  kconfig-ext: True


### PR DESCRIPTION
Use external Kconfig files for the Segger module.