### PR TITLE
config: SEGGER_RTT_Conf: remove mutex locking

### DIFF
--- a/Config/SEGGER_RTT_Conf.h
+++ b/Config/SEGGER_RTT_Conf.h
@@ -153,19 +153,12 @@ Revision: $Rev: 24316 $
 */
 #if ((defined(__SES_ARM) || defined(__SES_RISCV) || defined(__CROSSWORKS_ARM) || defined(__GNUC__) || defined(__clang__)) && !defined (__CC_ARM) && !defined(WIN32))
   #if defined(__ZEPHYR__) && defined (CONFIG_SEGGER_RTT_CUSTOM_LOCKING)
-    #ifdef CONFIG_MULTITHREADING
-      extern void zephyr_rtt_mutex_lock(void);
-      extern void zephyr_rtt_mutex_unlock(void);
-      #define SEGGER_RTT_LOCK() zephyr_rtt_mutex_lock()
-      #define SEGGER_RTT_UNLOCK() zephyr_rtt_mutex_unlock()
-    #else
-      extern unsigned int zephyr_rtt_irq_lock(void);
-      extern void zephyr_rtt_irq_unlock(unsigned int key);
-      #define SEGGER_RTT_LOCK() { \
-	unsigned int key = zephyr_rtt_irq_lock()
-      #define SEGGER_RTT_UNLOCK() zephyr_rtt_irq_unlock(key); \
-        }
-      #endif
+    extern unsigned int zephyr_rtt_irq_lock(void);
+    extern void zephyr_rtt_irq_unlock(unsigned int key);
+    #define SEGGER_RTT_LOCK() { \
+      unsigned int key = zephyr_rtt_irq_lock()
+    #define SEGGER_RTT_UNLOCK() zephyr_rtt_irq_unlock(key); \
+      }
    #define RTT_USE_ASM 0
   #elif (defined(__ARM_ARCH_6M__) || defined(__ARM_ARCH_8M_BASE__))
     #define SEGGER_RTT_LOCK()   {                                                                   \


### PR DESCRIPTION
Remove mutex locking in favour of the standard IRQ locking mechanism. The primary problem with the mutex implementation is that mutex locking is forbidden in ISR's. This means that any logging from an interrupt context (e.g. LOG_PANIC in an exception handler), will itself trigger another assertion due its attempt to use a mutex.

Furthermore, mutexes are a relatively heavyweight locking scheme, which doesn't necessarily make sense in the context of extremely short locking periods that would be expected from RTT.

This change aligns Zephyr with the default RTT locking scheme, which uses interrupt masking to perform access control.